### PR TITLE
Fixed : User settings shows uuids instead of names as sync attributes #968

### DIFF
--- a/src/adminApp/user.js
+++ b/src/adminApp/user.js
@@ -61,7 +61,6 @@ import Grid from "@material-ui/core/Grid";
 import ConceptService from "../common/service/ConceptService";
 import Select from "react-select";
 import ReactSelectHelper from "../common/utils/ReactSelectHelper";
-import { error } from "jquery";
 
 export const UserCreate = ({ user, organisation, userInfo, ...props }) => (
   <Paper>
@@ -186,22 +185,17 @@ const ConceptSyncAttributeShow = ({ subjectType, syncAttributeName, ...props }) 
   const conceptUUID = get(syncSettings, [syncAttributeName]);
   if (isEmpty(conceptUUID)) return null;
 
-  const [valueMap, setValueMap] = useState(new Map());
+  const [syncConceptValueMap, setSyncConceptValueMap] = useState(new Map());
   useEffect(() => {
     let isMounted = true;
     const newValMap = new Map();
 
-    ConceptService.getAnswerConcepts(conceptUUID)
-      .then(content => {
-        content.forEach(val => newValMap.set(val.id, val.name));
-        if (isMounted) {
-          setValueMap(newValMap);
-        }
-      })
-      .catch(error => {
-        console.error("Error fetching data:", error);
-      });
-    // console.log("value============>",newValMap.size,newValMap);
+    ConceptService.getAnswerConcepts(conceptUUID).then(content => {
+      content.forEach(val => newValMap.set(val.id, val.name));
+      if (isMounted) {
+        setSyncConceptValueMap(newValMap);
+      }
+    });
     return () => {
       isMounted = false;
     };
@@ -212,7 +206,7 @@ const ConceptSyncAttributeShow = ({ subjectType, syncAttributeName, ...props }) 
         {startCase(syncAttributeName)}
       </span>
       {map(get(syncSettings, `${syncAttributeName}Values`, []), value => (
-        <Chip style={{ margin: "0.2em" }} label={valueMap.get(value)} key={value} />
+        <Chip style={{ margin: "0.2em" }} label={syncConceptValueMap.get(value)} key={value} />
       ))}
     </div>
   );

--- a/src/adminApp/user.js
+++ b/src/adminApp/user.js
@@ -184,13 +184,22 @@ const ConceptSyncAttributeShow = ({ subjectType, syncAttributeName, ...props }) 
   const syncSettings = get(props.record, ["syncSettings", subjectType.name], {});
   const conceptUUID = get(syncSettings, [syncAttributeName]);
   if (isEmpty(conceptUUID)) return null;
+
+  const [valueMap, setValueMap] = useState(new Map());
+  useEffect(() => {
+    const newValMap = new Map();
+    ConceptService.getAnswerConcepts(conceptUUID).then(content =>
+      content.forEach(val => newValMap.set(val.id, val.name))
+    );
+    setValueMap(newValMap);
+  }, []);
   return (
     <div>
       <span style={{ color: "rgba(0, 0, 0, 0.54)", fontSize: "12px", marginRight: 10 }}>
         {startCase(syncAttributeName)}
       </span>
       {map(get(syncSettings, `${syncAttributeName}Values`, []), value => (
-        <Chip label={value} key={value} />
+        <Chip style={{ margin: "0.2em" }} label={valueMap.get(value)} key={value} />
       ))}
     </div>
   );
@@ -297,8 +306,8 @@ const operatingScopes = Object.freeze({
   CATCHMENT: "ByCatchment"
 });
 
-const catchmentChangeMessage = `Please ensure that the user has already synced all 
-data for their previous sync attributes. Changing sync attributes will ask the users to reset their sync. 
+const catchmentChangeMessage = `Please ensure that the user has already synced all
+data for their previous sync attributes. Changing sync attributes will ask the users to reset their sync.
 This might take time depending on the data.`;
 
 const SubjectTypeSyncAttributes = ({ subjectType, ...props }) => (

--- a/src/adminApp/user.js
+++ b/src/adminApp/user.js
@@ -61,6 +61,7 @@ import Grid from "@material-ui/core/Grid";
 import ConceptService from "../common/service/ConceptService";
 import Select from "react-select";
 import ReactSelectHelper from "../common/utils/ReactSelectHelper";
+import { error } from "jquery";
 
 export const UserCreate = ({ user, organisation, userInfo, ...props }) => (
   <Paper>
@@ -187,12 +188,24 @@ const ConceptSyncAttributeShow = ({ subjectType, syncAttributeName, ...props }) 
 
   const [valueMap, setValueMap] = useState(new Map());
   useEffect(() => {
+    let isMounted = true;
     const newValMap = new Map();
-    ConceptService.getAnswerConcepts(conceptUUID).then(content =>
-      content.forEach(val => newValMap.set(val.id, val.name))
-    );
-    setValueMap(newValMap);
-  }, []);
+
+    ConceptService.getAnswerConcepts(conceptUUID)
+      .then(content => {
+        content.forEach(val => newValMap.set(val.id, val.name));
+        if (isMounted) {
+          setValueMap(newValMap);
+        }
+      })
+      .catch(error => {
+        console.error("Error fetching data:", error);
+      });
+    // console.log("value============>",newValMap.size,newValMap);
+    return () => {
+      isMounted = false;
+    };
+  }, [conceptUUID]);
   return (
     <div>
       <span style={{ color: "rgba(0, 0, 0, 0.54)", fontSize: "12px", marginRight: 10 }}>


### PR DESCRIPTION
# Notes :

Fixes #968

### Presupposition :
For user, it become easy if we shows concpet value in sync attribute.

### Tech Task :
1. Find related component **ConceptSyncAttributeShow** in user.js.
2. fetch answerconcept if **conceptUUID** is available.
3. Replaced uuid with name attribute.
   
### Dev Test :

**User with sync attribute:**
1. checked with (http://localhost:6010/#/admin/user/699/show)
2. reloading the page.
   
**User without sync attribute:**
1. checked page is not breaking


### Other Fixes:
As we can see there is no space between two skeleton of sync attribute. So I added margin


### Result : 
<img width="754" alt="Screenshot 2023-11-28 at 9 25 14 AM" src="https://github.com/avniproject/avni-webapp/assets/106894932/429781b3-b038-4641-a70a-4ed5f1bb36dd">

