### PR TITLE
#1124 | Option to add and view Colors for Report Card removed!

### DIFF
--- a/src/formDesigner/components/ReportCard/CreateEditReportCard.js
+++ b/src/formDesigner/components/ReportCard/CreateEditReportCard.js
@@ -134,11 +134,7 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
       ]);
       isValid = false;
     }
-    if (
-      !isStandardReportCard &&
-      nested &&
-      (count < MinimumNumberOfNestedCards || count > MaximumNumberOfNestedCards)
-    ) {
+    if (!isStandardReportCard && nested && (count < MinimumNumberOfNestedCards || count > MaximumNumberOfNestedCards)) {
       setError([
         ...error,
         {
@@ -181,9 +177,7 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
           setError([
             {
               key: "SERVER_ERROR",
-              message: `${get(error, "response.data") ||
-                get(error, "message") ||
-                "error while saving card"}`
+              message: `${get(error, "response.data") || get(error, "message") || "error while saving card"}`
             }
           ]);
         });
@@ -237,14 +231,18 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
           toolTipKey={"APP_DESIGNER_CARD_DESCRIPTION"}
         />
         <p />
-        <AvniFormLabel label={"Colour Picker"} toolTipKey={"APP_DESIGNER_CARD_COLOR"} />
-        <PopoverColorPicker
-          id="colour"
-          label="Colour"
-          color={card.color}
-          onChange={color => dispatch({ type: "color", payload: color })}
-        />
-        {getErrorByKey(error, "EMPTY_COLOR")}
+        {!isStandardReportCard && (
+          <React.Fragment>
+            <AvniFormLabel label={"Colour Picker"} toolTipKey={"APP_DESIGNER_CARD_COLOR"} />
+            <PopoverColorPicker
+              id="colour"
+              label="Colour"
+              color={card.color}
+              onChange={color => dispatch({ type: "color", payload: color })}
+            />
+            {getErrorByKey(error, "EMPTY_COLOR")}
+          </React.Fragment>
+        )}
         <p />
         <AvniImageUpload
           onSelect={setFile}
@@ -290,13 +288,11 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
                 payload: { nested: card.nested, count: event.target.value }
               })
             }
-            options={Array.from({ length: MaximumNumberOfNestedCards }, (_, i) => i + 1).map(
-              (num, index) => (
-                <MenuItem value={num} key={index}>
-                  {num}
-                </MenuItem>
-              )
-            )}
+            options={Array.from({ length: MaximumNumberOfNestedCards }, (_, i) => i + 1).map((num, index) => (
+              <MenuItem value={num} key={index}>
+                {num}
+              </MenuItem>
+            ))}
             toolTipKey={"APP_DESIGNER_CARD_COUNT"}
           />
         )}

--- a/src/formDesigner/components/ReportCard/ReportCardList.js
+++ b/src/formDesigner/components/ReportCard/ReportCardList.js
@@ -7,8 +7,7 @@ import { Privilege } from "openchs-models";
 const columns = [
   {
     title: "Name",
-    render: rowData =>
-      !rowData.voided && <a href={`#/appDesigner/reportCard/${rowData.id}/show`}>{rowData.name}</a>
+    render: rowData => !rowData.voided && <a href={`#/appDesigner/reportCard/${rowData.id}/show`}>{rowData.name}</a>
   },
   {
     title: "Description",

--- a/src/formDesigner/components/ReportCard/ReportCardShow.js
+++ b/src/formDesigner/components/ReportCard/ReportCardShow.js
@@ -43,11 +43,13 @@ const ReportCardShow = props => {
         <p />
         <ShowLabelValue label={"Description"} value={card.description} />
         <p />
-        <div>
-          <FormLabel style={{ fontSize: "13px" }}>{"Colour"}</FormLabel>
-          <br />
-          <ColorValue colour={card.color} />
-        </div>
+        {!isStandardReportCard && (
+          <React.Fragment>
+            <FormLabel style={{ fontSize: "13px" }}>{"Colour"}</FormLabel>
+            <br />
+            <ColorValue colour={card.color} />
+          </React.Fragment>
+        )}
         <p />
         {!isStandardReportCard && (
           <React.Fragment>
@@ -70,10 +72,7 @@ const ReportCardShow = props => {
         <p />
         {isStandardReportCard && (
           <React.Fragment>
-            <ShowLabelValue
-              label={"Standard Report Card Type"}
-              value={standardReportCardType.name}
-            />
+            <ShowLabelValue label={"Standard Report Card Type"} value={standardReportCardType.name} />
             <p />
           </React.Fragment>
         )}


### PR DESCRIPTION
This PR fixes #1124  . Option to add and view colours for Report Card removed!
<img width="1423" alt="CRC" src="https://github.com/avniproject/avni-webapp/assets/115864495/24a5dcfb-6c57-4cc1-86fe-21583322f833">
<img width="1428" alt="ORC" src="https://github.com/avniproject/avni-webapp/assets/115864495/d38d964e-3e3f-472b-958d-5247fd35db13">
<img width="1438" alt="VRC" src="https://github.com/avniproject/avni-webapp/assets/115864495/ebdc23cd-f125-43da-9d6b-0b72dde601ee">
