### PR TITLE
#1297 | Error handling for duplicate card entry.

### DIFF
--- a/src/formDesigner/components/ReportCard/CreateEditReportCard.js
+++ b/src/formDesigner/components/ReportCard/CreateEditReportCard.js
@@ -36,6 +36,18 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
   const [isStandardReportCard, setIsStandardReportCard] = React.useState(false);
   const [standardReportCardTypes, setStandardReportCardTypes] = React.useState([]);
   const [file, setFile] = React.useState();
+  const [cardName, setCardName] = React.useState(new Set());
+
+  const cardNameSet = new Set(cardName);
+
+  React.useEffect(() => {
+    DashboardService.getAllReportCards().then(res => {
+      res.forEach(item => {
+        cardNameSet.add(item.name);
+        setCardName(cardNameSet);
+      });
+    });
+  }, []);
 
   React.useEffect(() => {
     if (edit) {
@@ -79,6 +91,16 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
   };
 
   const onSave = async () => {
+    console.log(cardNameSet);
+    if (cardNameSet.has(card.name)) {
+      setError([
+        {
+          key: "DUPLICATE_ENTRY",
+          message: `Card with name '${card.name}' already exists.`
+        }
+      ]);
+      return;
+    }
     if (validateRequest()) {
       const [s3FileKey, error] = await uploadImage(card.iconFileS3Key, file, bucketName.ICONS);
       if (error) {
@@ -293,6 +315,8 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
         {getErrorByKey(error, "DISALLOWED_NESTED")}
         <p />
         {getErrorByKey(error, "INVALID_NESTED_CARD_COUNT")}
+        <p />
+        {getErrorByKey(error, "DUPLICATE_ENTRY")}
         <br />
         <Grid container direction={"row"}>
           <Grid item xs={1}>

--- a/src/formDesigner/components/ReportCard/CreateEditReportCard.js
+++ b/src/formDesigner/components/ReportCard/CreateEditReportCard.js
@@ -96,7 +96,7 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
       setError([
         {
           key: "DUPLICATE_ENTRY",
-          message: `Card with name '${card.name}' already exists.`
+          message: "Report Card with same name already exists."
         }
       ]);
       return;
@@ -164,6 +164,7 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
           toolTipKey={"APP_DESIGNER_CARD_NAME"}
         />
         {getErrorByKey(error, "EMPTY_NAME")}
+        {getErrorByKey(error, "DUPLICATE_ENTRY")}
         <p />
         <AvniTextField
           multiline
@@ -315,8 +316,6 @@ export const CreateEditReportCard = ({ edit, ...props }) => {
         {getErrorByKey(error, "DISALLOWED_NESTED")}
         <p />
         {getErrorByKey(error, "INVALID_NESTED_CARD_COUNT")}
-        <p />
-        {getErrorByKey(error, "DUPLICATE_ENTRY")}
         <br />
         <Grid container direction={"row"}>
           <Grid item xs={1}>


### PR DESCRIPTION
When a report card with an already existing name is created show proper error message #1297 

![image](https://github.com/user-attachments/assets/c98ef37b-6cba-4874-89f6-20a1db32c359)
