### PR TITLE
Fix: Catchment dropdown should not float (#1272)

### DIFF
--- a/src/adminApp/components/CatchmentSelectInput.js
+++ b/src/adminApp/components/CatchmentSelectInput.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { AutocompleteInput } from "react-admin";
+import { SelectInput } from "react-admin";
 
 export const CatchmentSelectInput = props => {
-  return <AutocompleteInput {...props} choices={props.choices} optionText="name" />;
+  return <SelectInput {...props} choices={props.choices} optionText="name" />;
 };


### PR DESCRIPTION
   Fix: Catchment dropdown should not float (#1272)
   
   This PR fixes issue #1272 where the Catchment dropdown floats when scrolling instead of staying with its input field.
   
   ## Solution
   After investigating several approaches, I found that replacing AutocompleteInput with SelectInput provides the most reliable solution:
   
   - It uses native HTML select elements which browsers handle correctly during scrolling
   - It maintains compatibility with all existing props and parent components
   - The trade-off is losing typeahead functionality, but gaining proper scroll behavior
   
   The root cause was related to how Material-UI v4 and react-admin 2.7.2 handle dropdown positioning in different contexts.