### PR TITLE
Fix: Error when saving concept names with spaces

### DIFF
--- a/src/formDesigner/views/CreateEditConcept.js
+++ b/src/formDesigner/views/CreateEditConcept.js
@@ -438,7 +438,9 @@ class CreateEditConcept extends Component {
   handleSubmit = e => {
     e.preventDefault();
 
-    this.formValidation();
+    this.setState({ name: this.state.name.trim() }, () => {
+      this.formValidation();
+    });
   };
 
   afterSuccessfullValidation = () => {


### PR DESCRIPTION
## Related issue
Closes #1439 

## Description
There was an issue where saving an existing concept with leading or trailing spaces in the name would cause an error. This happened because the extra spaces prevented the system from correctly checking if the concept already existed.

To fix this, I added a trim() before the validation step. Now, any spaces at the beginning or end of the concept name are removed before checking against existing entries. This ensures that the validation works properly, and if a concept with the same name already exists, it correctly shows the message:
"Same name concept already exists."

## Before Update

https://github.com/user-attachments/assets/05ab8b8c-838c-4c2e-9e08-e9d41bc7e4fc

## After Update

https://github.com/user-attachments/assets/a32d2cb9-779a-4579-bd5a-a0767cd82554


