### PR TITLE
Fix: Manual Eligibility Check Required Option Not Retained

### DIFF
--- a/src/adminApp/Constant.js
+++ b/src/adminApp/Constant.js
@@ -5,6 +5,7 @@ export const programInitialState = {
   enrolmentSummaryRule: "",
   enrolmentEligibilityCheckRule: "",
   manualEnrolmentEligibilityCheckRule: "",
+  manualEligibilityCheckRequired: false,
   loaded: false
 };
 

--- a/src/adminApp/Program/EditProgramFields.js
+++ b/src/adminApp/Program/EditProgramFields.js
@@ -128,7 +128,7 @@ const EditProgramFields = props => {
 
       <br />
       <AvniSwitch
-        checked={program.allow}
+        checked={program.manualEligibilityCheckRequired}
         onChange={event => dispatch({ type: "manualEligibilityCheckRequired", payload: event.target.checked })}
         name="Manual eligibility check required"
         toolTipKey={"APP_DESIGNER_PROGRAM_MANUAL_ELIGIBILITY_CHECK_REQUIRED"}

--- a/src/adminApp/Program/ProgramShow.js
+++ b/src/adminApp/Program/ProgramShow.js
@@ -99,7 +99,7 @@ const ProgramShow = props => {
           <p />
           <BooleanStatusInShow status={program.active} label={"Active"} />
           <BooleanStatusInShow status={program.allowMultipleEnrolments} label={"Allow multiple active enrolments"} />
-
+          <BooleanStatusInShow status={program.manualEligibilityCheckRequired} label={"Manual eligibility check required"} />
           <div>
             <FormLabel style={{ fontSize: "13px" }}>Program Subject Label</FormLabel>
             <br />


### PR DESCRIPTION
 Closes #1495 
 
 
 This PR fixes the manual eligibility check required not getting retained after saving in the program enrollment 