### PR TITLE
Fixes 1465 - Program name allows spaces in app designer

### DIFF
--- a/src/adminApp/Program/EditProgramFields.js
+++ b/src/adminApp/Program/EditProgramFields.js
@@ -43,6 +43,7 @@ const EditProgramFields = props => {
         value={program.name}
         onChange={event => dispatch({ type: "name", payload: event.target.value })}
         toolTipKey={"APP_DESIGNER_PROGRAM_NAME"}
+        error={/\s/.test(program.name) ? "Spaces are not allowed in program name" : ""}
       />
       <br />
       {!_.isNil(errors.get("Name")) && (


### PR DESCRIPTION
## Fixes #1465 - Program name allows spaces in app designer

### Summary

This PR adds a validation to the program name field in the App Designer so that spaces are not allowed in program names. Previously, it was possible to enter program names with spaces, which could cause issues elsewhere in the system.

### Changes

- Updated `src/adminApp/Program/EditProgramFields.js` to disallow spaces in the program name input.
- Added UI feedback (error message) if a user enters a space in the program name field.

### How to Test

1. Go to the App Designer and try to create or edit a program.
2. Try entering a name with spaces (e.g., `"My Program"`).
3. You should see an error message stating that spaces are not allowed, and the form should prevent you from submitting.

### Screenshots (if applicable)

_Add screenshots here if you took any of the validation/error in action._

### Notes

- The validation is implemented in the UI, but you may want to consider adding backend validation as well for complete safety.
- Please let me know if any further changes are required!

---

Fixes #1465