### PR TITLE
Fix: DEA crash on subject profile tab (closes #1542)

### DIFF
--- a/src/dataEntryApp/views/subjectDashBoard/components/GridCommonList.jsx
+++ b/src/dataEntryApp/views/subjectDashBoard/components/GridCommonList.jsx
@@ -50,7 +50,15 @@ const GridCommonList = ({ profileUUID, profileName, gridListDetails }) => {
     <StyledGridContainer container size={12}>
       {gridListDetails &&
         gridListDetails
-          .filter(relative => relative !== undefined && !relative.voided)
+          .filter(
+            relative =>
+              relative !== undefined &&
+              !relative.voided &&
+              relative.individualB &&
+              relative.individualB.subjectType &&
+              relative.individualB.subjectType.type &&
+              relative.individualB.subjectType.name
+          )
           .map((relative, index) => (
             <StyledGridItem key={index} size={3}>
               <StyledCard>


### PR DESCRIPTION
### Description

**Bug Fix: DEA crash on subject profile tab (closes #1542)**

This pull request addresses the bug where the application crashes when a user navigates to the profile tab for a specific subject, as described in issue #1542.

#### Root Cause

The crash was caused by a data inconsistency for one of the subject's relatives. The `subjectType` object for this relative was either incomplete or missing essential properties, such as `type` or `name`. The `GridCommonList.jsx` component's filter, which is responsible for rendering the list of relatives, was not robust enough to catch this invalid data. As a result, an incomplete `subjectType` object was passed to the `SubjectProfilePicture` component, causing it to crash when it attempted to access `subjectType.type`.

#### Solution

To fix this, I have enhanced the filtering logic in `GridCommonList.jsx`. The filter now includes an additional check to ensure that the `subjectType` object and its required properties (`type` and `name`) exist before a relative is rendered.

```diff
- relative.individualB.subjectType.type
+ relative.individualB.subjectType.type &&
+ relative.individualB.subjectType.name