### PR TITLE
Remove IdentifierSource edit option (fixes #1564)

### DIFF
--- a/src/adminApp/OrgManager.jsx
+++ b/src/adminApp/OrgManager.jsx
@@ -175,7 +175,7 @@ const OrgManager = () => {
             IdentifierSourceCreate
           }
           edit={
-            hasPrivilege(userInfo, EditIdentifierSource) && IdentifierSourceEdit
+            false
           }
         />
         <Resource


### PR DESCRIPTION
Removed the edit option for the IdentifierSource

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editing for the Identifier Source in the Admin UI is now disabled; creation remains subject to existing privilege checks.
  * This change affects only the Identifier Source section; all other resources and workflows remain unchanged in the Admin UI.
  * Edit controls for this resource will no longer appear.
  * Applies to all users, regardless of previous edit privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->