### PR TITLE
#1397 | Fix incorrect age sorting order in search results

### DIFF
--- a/src/dataEntryApp/views/search/SubjectSearchTable.jsx
+++ b/src/dataEntryApp/views/search/SubjectSearchTable.jsx
@@ -190,11 +190,19 @@ const SubjectSearchTable = ({ searchRequest, organisationConfigs }) => {
         requestCopy.subjectType = firstSubjectTypeUUID;
       }
 
+      let sortColumn = sorting[0]?.id || null;
+      let sortOrder = sorting[0]?.desc ? "desc" : sorting[0]?.id ? "asc" : null;
+
+      // Fix Age sorting (Age is derived from dateOfBirth)
+      if (sortColumn === "dateOfBirth") {
+        sortOrder = sortOrder === "asc" ? "desc" : "asc";
+      }
+
       const pageElement = {
         pageNumber: pagination.pageIndex,
         numberOfRecordPerPage: pagination.pageSize,
-        sortColumn: sorting[0]?.id || null,
-        sortOrder: sorting[0]?.desc ? "desc" : sorting[0]?.id ? "asc" : null,
+        sortColumn,
+        sortOrder,
       };
 
       requestCopy.pageElement = pageElement;


### PR DESCRIPTION
## Fix
Age sorting in search results was incorrect because Age is derived from `dateOfBirth`.  
Sorting by Age was applying the same order on `dateOfBirth`, which resulted in reversed ordering.

This fix adjusts the sort order when sorting by `dateOfBirth` so that Age sorting behaves correctly.

Closes #1397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date of birth sorting behavior in search results to display records in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->