### PR TITLE
Fix : Collapse Templates section after template application

### DIFF
--- a/src/adminApp/AppDesignerSubmenu.jsx
+++ b/src/adminApp/AppDesignerSubmenu.jsx
@@ -4,17 +4,19 @@ import ExpandLess from "@mui/icons-material/ExpandLess";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 import ListItemText from "@mui/material/ListItemText";
 import Collapse from "@mui/material/Collapse";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 const Submenu = ({ text, icon, children }) => {
   const location = useLocation();
-  const [open, setOpen] = useState(() => {
-    return (
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const shouldOpen =
       location.pathname.startsWith("/appdesigner") &&
-      !location.pathname.startsWith("/appdesigner/templates")
-    );
-  });
+      !location.pathname.startsWith("/appdesigner/templates");
+    setOpen(shouldOpen);
+  }, [location.pathname]);
 
   const handleClick = () => {
     setOpen(!open);

--- a/src/formDesigner/components/TemplateOrganisations/ApplyTemplateDialog.jsx
+++ b/src/formDesigner/components/TemplateOrganisations/ApplyTemplateDialog.jsx
@@ -167,9 +167,6 @@ export const ApplyTemplateDialog = ({
             clearInterval(newIntervalId);
             setIsSubmitting(false);
             localStorage.removeItem(TEMPLATE_APPLY_PROGRESS_KEY);
-            if (applyTemplateJob.status === "COMPLETED" && onApplySuccess) {
-              onApplySuccess();
-            }
           }
         })
         .catch((error) => {
@@ -223,6 +220,13 @@ export const ApplyTemplateDialog = ({
 
   const handleClose = () => {
     if (isSubmitting && !isTerminalStatus(applyStatus)) return;
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    if (applyStatus === "COMPLETED" && onApplySuccess) {
+      onApplySuccess();
+    }
     onClose();
   };
 
@@ -319,7 +323,7 @@ export const ApplyTemplateDialog = ({
             }}
           >
             <Button
-              onClick={handleClose}
+              onClick={handleConfirm}
               disabled={!isTerminalStatus(applyStatus)}
               variant="contained"
               sx={{ minWidth: BUTTON_CONFIG.minWidth }}

--- a/src/formDesigner/components/TemplateOrganisations/TemplateOrganisations.jsx
+++ b/src/formDesigner/components/TemplateOrganisations/TemplateOrganisations.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Title } from "react-admin";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
@@ -303,9 +303,9 @@ export const TemplateOrganisations = () => {
     setSelectedTemplate(template);
   };
 
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     setSelectedTemplate(null);
-  };
+  }, []);
 
   return (
     <Box
@@ -329,6 +329,7 @@ export const TemplateOrganisations = () => {
         <TemplateOrganisationDetail
           template={selectedTemplate}
           onBack={handleBack}
+          onApplySuccess={handleBack}
         />
       ) : (
         <div>


### PR DESCRIPTION
Fixe where the Templates section remained open after successfully applying a template.

## Changes

### TemplateOrganisations.jsx
- Memoized `handleBack` using `useCallback`.
- Reset `selectedTemplate` after successful template application to close the Templates detail view.

### ApplyTemplateDialog.jsx
- Ensured `onApplySuccess` triggers **only when the user explicitly clicks `OK`** on the success dialog.
- Prevented redirects when the dialog is closed using backdrop click or `ESC`.

### AppDesignerSubmenu.jsx
- Synchronized submenu open state with the current route using `useEffect`.
- Submenu remains **collapsed on `/appdesigner/templates`** and expands for other `/appdesigner/*` routes.

## Result

After confirming the success dialog:
- The Templates detail view closes.
- The user returns to the main App Designer view.
- The App Designer submenu state stays consistent with the current route.

## Testing

Manually verified:
- Template application flow from template card and template details page.
- Success dialog confirmation redirects correctly.
- Backdrop / `ESC` close does not trigger redirect.
- Submenu expands/collapses correctly based on route.