### PR TITLE
Fix: User not displayed in Identifier User Assignment dropdown (#1756)

### DIFF
--- a/src/adminApp/AccountOrgAdminUser.jsx
+++ b/src/adminApp/AccountOrgAdminUser.jsx
@@ -179,7 +179,7 @@ const UserFormFields = ({ edit = false, region }) => {
         perPage={1000}
         label="Accounts"
         validate={required("Please select one or more accounts")}
-        filterToQuery={searchText => ({ name: searchText })}
+ filterToQuery={searchText => ({ username: searchText, name: searchText })}
       >
         <StyledAutocompleteArrayInput />
       </ReferenceArrayInput>


### PR DESCRIPTION
Fixes #1756

- Updated filterToQuery to use `username` instead of `name`
- Ensures users returned by API are correctly displayed in dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account search now matches against both username and name fields, improving search result discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->