### PR TITLE
Fix: Add whitespace validation and normalization for Admin creation (#1444)

### DIFF
--- a/src/adminApp/AccountOrgAdminUser.jsx
+++ b/src/adminApp/AccountOrgAdminUser.jsx
@@ -199,10 +199,13 @@ const UserFormFields = ({ edit = false, region }) => {
       ) : (
         <>
           <StyledTextInput
-            source="username"
-            validate={validateUserName}
-            label="Login ID (username)"
-            parse={(value) => (value ? value.replace(/\s+/g, " ") : value)}
+            source="name"
+            label="Name of the Person"
+            validate={validateDisplayName}
+            parse={(value) =>
+              value ? value.trim().replace(/\s+/g, " ") : value
+            }
+            autoComplete={autoComplete}
           />
         </>
       )}

--- a/src/adminApp/AccountOrgAdminUser.jsx
+++ b/src/adminApp/AccountOrgAdminUser.jsx
@@ -16,7 +16,7 @@ import {
   TextField,
   required,
   useRecordContext,
-  useResourceContext
+  useResourceContext,
 } from "react-admin";
 import { useFormContext, useWatch } from "react-hook-form";
 import CardActions from "@mui/material/CardActions";
@@ -29,7 +29,9 @@ import {
   PasswordTextField,
   UserFilter,
   UserTitle,
-  validateEmail
+  validateEmail,
+  validateUserName,
+  validateDisplayName,
 } from "./UserHelper";
 import { TitleChip } from "./components/TitleChip";
 import OrganisationService from "../common/service/OrganisationService";
@@ -40,7 +42,7 @@ import {
   datagridStyles,
   StyledAutocompleteArrayInput,
   StyledShow,
-  StyledSimpleShowLayout
+  StyledSimpleShowLayout,
 } from "./Util/Styles";
 import { PrettyPagination } from "./Util/PrettyPagination.tsx";
 
@@ -63,7 +65,7 @@ export const AccountOrgAdminUserEdit = ({ user, region, ...props }) => (
   </Edit>
 );
 
-export const AccountOrgAdminUserList = props => (
+export const AccountOrgAdminUserList = (props) => (
   <StyledBox>
     <List
       {...props}
@@ -81,12 +83,12 @@ export const AccountOrgAdminUserList = props => (
         <TextField source="phoneNumber" label="Phone Number" />
         <FunctionField
           label="Status"
-          render={user =>
+          render={(user) =>
             user.voided === true
               ? "Deleted"
               : user.disabledInCognito === true
-              ? "Disabled"
-              : "Active"
+                ? "Disabled"
+                : "Active"
           }
         />
       </Datagrid>
@@ -116,7 +118,7 @@ export const AccountOrgAdminUserDetail = ({ user, ...props }) => (
       <TextField source="name" label="Name of the Person" />
       <TextField source="email" label="Email Address" />
       <TextField source="phoneNumber" label="Phone Number" />
-      <FunctionField label="Role" render={user => formatRoles(user.roles)} />
+      <FunctionField label="Role" render={(user) => formatRoles(user.roles)} />
       <ReferenceField
         label="Organisation"
         source="organisationId"
@@ -159,7 +161,7 @@ const UserFormFields = ({ edit = false, region }) => {
 
   useEffect(() => {
     if (organisationId) {
-      OrganisationService.getOrganisation(organisationId).then(data => {
+      OrganisationService.getOrganisation(organisationId).then((data) => {
         setNameSuffix(data?.usernameSuffix || "");
       });
     }
@@ -179,7 +181,7 @@ const UserFormFields = ({ edit = false, region }) => {
         perPage={1000}
         label="Accounts"
         validate={required("Please select one or more accounts")}
-        filterToQuery={searchText => ({ name: searchText })}
+        filterToQuery={(searchText) => ({ name: searchText })}
       >
         <StyledAutocompleteArrayInput />
       </ReferenceArrayInput>
@@ -198,11 +200,10 @@ const UserFormFields = ({ edit = false, region }) => {
         <>
           <StyledTextInput
             source="username"
-            validate={isRequired}
+            validate={validateUserName}
             label="Login ID (username)"
+            parse={(value) => (value ? value.replace(/\s+/g, " ") : value)}
           />
-          {nameSuffix && <span>@{nameSuffix}</span>}
-          <StyledTextInput source="username" style={{ display: "none" }} />
         </>
       )}
 
@@ -210,7 +211,8 @@ const UserFormFields = ({ edit = false, region }) => {
       <StyledTextInput
         source="name"
         label="Name of the Person"
-        validate={isRequired}
+        validate={validateDisplayName}
+        parse={(value) => (value ? value.replace(/\s+/g, " ") : value)}
         autoComplete={autoComplete}
       />
       <StyledTextInput

--- a/src/adminApp/UserHelper.jsx
+++ b/src/adminApp/UserHelper.jsx
@@ -87,7 +87,7 @@ export const doesNotStartOrEndWithWhitespaces = regex(
 
 export const validateUserName = [
   isRequired,
-  doesNotStartOrEndWithWhitespaces, // Reemplazamos doesNotHaveWhitespaces por esta
+  doesNotHaveWhitespaces, // Reverted to strict validation for AWS Cognito compatibility
   minLength(4, "Username too small, enter at least 4 characters."),
 ];
 

--- a/src/adminApp/UserHelper.jsx
+++ b/src/adminApp/UserHelper.jsx
@@ -5,7 +5,7 @@ import {
   regex,
   required,
   SaveButton,
-  Toolbar
+  Toolbar,
 } from "react-admin";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import { StyledTextInput } from "./Util/Styles";
@@ -21,14 +21,14 @@ export const UserTitle = ({ record, titlePrefix }) => {
   );
 };
 
-export const formatRoles = roles =>
+export const formatRoles = (roles) =>
   !isEmpty(roles) && // check required thanks to optimistic rendering shenanigans
   roles
-    .map(role =>
+    .map((role) =>
       role
         .split("_")
-        .map(word => word.replace(word[0], word[0].toUpperCase()))
-        .join(" ")
+        .map((word) => word.replace(word[0], word[0].toUpperCase()))
+        .join(" "),
     )
     .join(", ");
 
@@ -57,10 +57,10 @@ export const UserFilter = [
     source="phoneNumber"
     alwaysOn
     resettable={false}
-  />
+  />,
 ];
 
-export const CustomToolbar = props => (
+export const CustomToolbar = (props) => (
   <Toolbar {...props}>
     <SaveButton />
   </Toolbar>
@@ -78,48 +78,48 @@ export const PasswordTextField = () => (
 export const isRequired = required("This field is required");
 export const doesNotHaveWhitespaces = regex(
   /^\S+$/,
-  "This field should not contain whitespaces"
+  "This field should not contain whitespaces",
 );
 export const doesNotStartOrEndWithWhitespaces = regex(
   /^\S$|^\S[\s\S]*\S$/,
-  "This field should not start or end with whitespaces"
+  "This field should not start or end with whitespaces",
 );
 
 export const validateUserName = [
   isRequired,
-  doesNotHaveWhitespaces,
-  minLength(4, "Username too small, enter at least 4 characters.")
+  doesNotStartOrEndWithWhitespaces, // Reemplazamos doesNotHaveWhitespaces por esta
+  minLength(4, "Username too small, enter at least 4 characters."),
 ];
 
 export const validateEmail = [
   isRequired,
-  email("Please enter a valid email address")
+  email("Please enter a valid email address"),
 ];
 
 export const validateDisplayName = [
   isRequired,
-  doesNotStartOrEndWithWhitespaces
+  doesNotStartOrEndWithWhitespaces,
 ];
 
-const getValidatePhoneValidator = function(region) {
-  return value => {
+const getValidatePhoneValidator = function (region) {
+  return (value) => {
     const isValid = isValidPhoneNumber(value, region);
     return isValid ? undefined : "Invalid phone number";
   };
 };
 
-export const getPhoneValidator = function(region) {
+export const getPhoneValidator = function (region) {
   return [
     isRequired,
     doesNotStartOrEndWithWhitespaces,
-    getValidatePhoneValidator(region)
+    getValidatePhoneValidator(region),
   ];
 };
 
 export const validatePassword = [
   isRequired,
   doesNotStartOrEndWithWhitespaces,
-  minLength(8, "Password too small, enter at least 8 characters.")
+  minLength(8, "Password too small, enter at least 8 characters."),
 ];
 
 export const validatePasswords = ({ password, confirmPassword }) => {


### PR DESCRIPTION
This PR implements the requested validations for the Create Admins page:

1. Added whitespace validation (doesNotStartOrEndWithWhitespaces) to name and username fields to prevent backend creation if dirty data is submitted.

2. Added a parse function to the <StyledTextInput> components to normalize internal multiple spaces into a single space.

3. Ensured the Regex validation for LoginID is properly hooked into the React-Admin validate prop to block the form submission.

Note on Testing:
I successfully set up the project using make start-with-staging. However, as mentioned by @ombhardwajj in the issue comments, the dummy@osc account lacks super admin privileges on staging, so I couldn't visually test the rendering of the accountOrgAdmin resource. The code follows the standard redux-form and React-Admin patterns used throughout UserHelper.jsx. I would appreciate it if a maintainer could run a quick visual test on a local API setup!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced validation for username and display name with automatic whitespace normalization.

* **Bug Fixes**
  * Simplified username presentation during account creation; validation applied consistently.
  * Minor UI formatting tweaks in user list and details (role/status) for clearer, more consistent display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avniproject/avni-webapp/pull/1770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->